### PR TITLE
Use different endpoint and response code to verify

### DIFF
--- a/lib/omniauth/strategies/github_team_member.rb
+++ b/lib/omniauth/strategies/github_team_member.rb
@@ -8,8 +8,8 @@ module OmniAuth
       end
 
       def github_team_member?(id)
-        team_members = access_token.get("/teams/#{id}/members").parsed
-        !!team_members.detect { |member| member['login'] == raw_info['login'] }
+        response = access_token.get("/teams/#{id}/members/#{raw_info['login']}")
+        response.status == 204
       rescue ::OAuth2::Error
         false
       end


### PR DESCRIPTION
Apps I was using this on started breaking today, looks like the GitHub API maybe returns paginated results for members on a team now? Anyways, this updates the team check to get details on a specific team member now by their login.

https://developer.github.com/v3/orgs/teams/#get-team-member
