### PR TITLE
Change API to take method name and team id pairs

### DIFF
--- a/lib/omniauth/strategies/github_team_member.rb
+++ b/lib/omniauth/strategies/github_team_member.rb
@@ -5,8 +5,8 @@ module OmniAuth
     class GitHubTeamMember < OmniAuth::Strategies::GitHub
       credentials do
         options['teams'].inject({}) do |base, key_value_pair|
-          name, team_id = key_value_pair
-          base[team_method_name(name)] = team_member?(team_id)
+          method_name, team_id = key_value_pair
+          base[booleanize_method_name(method_name)] = team_member?(team_id)
           base
         end
       end
@@ -18,10 +18,9 @@ module OmniAuth
         false
       end
 
-      def team_method_name(name)
-        return name if name =~ /\?$/
-        return "#{name}?" if name =~ /_team$/
-        return "#{name}_team?"
+      def booleanize_method_name(method_name)
+        return method_name if method_name =~ /\?$/
+        return "#{method_name}?"
       end
     end
   end


### PR DESCRIPTION
This completely changes the API for omniauth-github-team-member. Before you set `GITHUB_TEAM_ID` in your env, but now you pass in a hash of method name and team id pairs.

``` ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :githubteammember,
    ENV["GITHUB_CLIENT_ID"],
    ENV["GITHUB_CLIENT_SECRET"],
    :scope => "user",
    :teams => {
      "mentors_team_member?" => 426344
    }
end
```

Now wherever I have an omniauth hash I can ask it `omniauth_hash.credentials.mentors_team_member?` to find out if the user is a member of the mentors team.

This lets you pass in as many different method name and team id pairs as you want, so you can do different things in different parts of your app based on different team memberships.

Note: You can leave the question mark off the method name and it will automatically append. We do this since the method will always return true or false, so in ruby land it should end with a `?`.
